### PR TITLE
20220628

### DIFF
--- a/components/theComponents/theHeader.vue
+++ b/components/theComponents/theHeader.vue
@@ -3,10 +3,11 @@
     <div class="navbar-start">
     </div>
     <div class="navbar-center">
+      <!-- TODO: デバイスが小さい時にP E T W E A Rを真ん中に配置したい -->
       <a href="/" class="btn btn-ghost normal-case text-xl">P E T W E A R</a>
     </div>
-    <div class="navbar-end">
-      <button class="btn btn-ghost">
+    <div class="navbar-end w-1/5 sm:w-1/2">
+      <button class="btn btn-ghost px-1 sm:px-4">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           class="h-6 w-6"
@@ -21,9 +22,9 @@
             d="M5.121 17.804A13.937 13.937 0 0112 16c2.5 0 4.847.655 6.879 1.804M15 10a3 3 0 11-6 0 3 3 0 016 0zm6 2a9 9 0 11-18 0 9 9 0 0118 0z"
           />
         </svg>
-        <span class="ml-2">今橋 陵さん</span>
+        <span class="hidden sm:inline-flex ml-2">今橋 陵さん</span>
       </button>
-      <button class="btn btn-ghost btn-circle">
+      <button class="btn btn-ghost btn-circle w-8 sm:w-12">
         <div class="indicator">
           <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/components/theComponents/theHeader.vue
+++ b/components/theComponents/theHeader.vue
@@ -4,6 +4,7 @@
     </div>
     <div class="navbar-center">
       <!-- TODO: デバイスが小さい時にP E T W E A Rを真ん中に配置したい -->
+      <!-- TODO: スペースを入れずに、CSSでテキストの幅を調整する -->
       <a href="/" class="btn btn-ghost normal-case text-xl">P E T W E A R</a>
     </div>
     <div class="navbar-end w-1/5 sm:w-1/2">

--- a/pages/coordinates/[id].vue
+++ b/pages/coordinates/[id].vue
@@ -1,7 +1,7 @@
 <template>
   <!-- パンくずリストとシェアボタン -->
   <!-- TODO: コンポーネント化  -->
-  <div class="flex justify-between">
+  <div class="sm:flex sm:justify-between">
     <div class="text-sm breadcrumbs">
       <ul>
         <li><a href="/">コーディネート一覧</a></li>
@@ -10,7 +10,7 @@
         <li>{{yearMonthDate(coordinateDetail.date)}}のコーディネート</li>
       </ul>
     </div>
-    <div class="mt-2">
+    <div class="flex flex-row-reverse mt-2">
       <button class="btn w-24 bg-accent text-white min-h-0 h-full flex p-2">
         <ShareIcon class="w-5 mr-0.5 shrink-0"/>
         <span>シェアする</span>

--- a/pages/coordinates/[id].vue
+++ b/pages/coordinates/[id].vue
@@ -37,9 +37,9 @@
   </div>
 
   <!-- ボディ -->
-  <div class="flex items-start bg-neutral">
+  <div class="sm:flex items-start bg-neutral">
     <!-- サブコンテンツ -->
-    <div class="w-3/5">
+    <div class="sm:w-3/5">
       <CoordinateImage
         :coordinateImgSrc="coordinateDetail.coordinateImgSrc"
         :watchedCount="coordinateDetail.watchedCount"
@@ -58,14 +58,14 @@
 
     </div>
     <!-- メインコンテンツ -->
-    <div class="w-2/5 p-4">
+    <div class="flex gap-x-2 sm:block sm:gap-x-0 sm:w-2/5 p-4">
       <CoordinateDetail
         :petName="coordinateDetail.petName"
         :itemName="coordinateDetail.itemName"
         :description="coordinateDetail.description"
         :date="coordinateDetail.date"
       />
-      <div class="w-full mt-4 px-4 py-4 bg-white border-2">
+      <div class="w-full sm:mt-4 px-4 py-4 bg-white border-2">
         <h1 class="text-lg">着用アイテム</h1>
         <div class="flex gap-2 items-center justify-center">
           <div class="flex flex-col items-center">


### PR DESCRIPTION
## やること
- コーディネート詳細をレスポンシブにする

## 気になっていること
-  デバイスが小さい時にヘッダーのP E T W E A Rを真ん中に配置したい
  - media max-width を指定してスタイルを当てれば良い
   ![image](https://user-images.githubusercontent.com/7611715/176067053-10c416ff-9dec-457a-9c97-d34a2d2ab6d9.png)
- 320px以下は崩れてもOK?